### PR TITLE
feat(debug): Surface server error stack trace in UI

### DIFF
--- a/api/enhance.ts
+++ b/api/enhance.ts
@@ -65,14 +65,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (error: any) {
     console.error('Error in /api/enhance:', error);
     const message = error.message || 'An unknown server error occurred.';
+    const debugInfo = process.env.NODE_ENV !== 'production' ? error.stack : undefined;
 
     // If headers are already sent, we must send the error through the stream
     if (res.headersSent) {
-      res.write(`data: ${JSON.stringify({ error: message })}\n\n`);
+      res.write(`data: ${JSON.stringify({ error: message, debug: debugInfo })}\n\n`);
       res.end();
     } else {
       // If headers are not sent, we can send a proper HTTP error response
-      res.status(500).json({ error: message });
+      res.status(500).json({ error: message, debug: debugInfo });
     }
   }
 }

--- a/components/EnhancedPromptForm.tsx
+++ b/components/EnhancedPromptForm.tsx
@@ -82,7 +82,11 @@ export default function EnhancedPromptForm() {
 
     if (!res.ok) {
       const err = await res.json();
-      setErrorLog(`❌ ${err.error || 'Internal Server Error'}`);
+      let errorDisplay = `❌ ${err.error || 'Internal Server Error'}`;
+      if (err.debug) {
+        errorDisplay += `\n\n--- Debug Info ---\n${err.debug}`;
+      }
+      setErrorLog(errorDisplay);
       setLoading(false);
       return;
     }
@@ -120,7 +124,11 @@ export default function EnhancedPromptForm() {
             }
 
             if (parsed.error) {
-              setErrorLog(parsed.error);
+              let errorDisplay = `❌ ${parsed.error}`;
+              if (parsed.debug) {
+                errorDisplay += `\n\n--- Debug Info ---\n${parsed.debug}`;
+              }
+              setErrorLog(errorDisplay);
             }
           } catch (err) {
             setErrorLog(prev => prev + `\n[stream parse error] ${line}`);


### PR DESCRIPTION
This commit enhances the application's error handling to improve debuggability.

Changes:
- The backend API (`/api/enhance`) now includes the `error.stack` in the JSON error payload when the environment is not `production`.
- The frontend component (`EnhancedPromptForm.tsx`) has been updated to check for this `debug` information in the error payload and display it in the error log section.

This will make it significantly faster to diagnose the root cause of server-side errors directly from the UI during development.