### PR TITLE
feat: Point frontend to external Cloud Run backend

### DIFF
--- a/components/EnhancedPromptForm.tsx
+++ b/components/EnhancedPromptForm.tsx
@@ -74,7 +74,9 @@ export default function EnhancedPromptForm() {
       },
     };
 
-    const res = await fetch('/api/enhance', {
+    const apiUrl = `${import.meta.env.VITE_API_BASE_URL || ''}/api/enhance`;
+
+    const res = await fetch(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),


### PR DESCRIPTION
This commit updates the application architecture by pointing the Vercel-hosted frontend to a separate backend running on Google Cloud Run.

The `fetch` call in `EnhancedPromptForm.tsx` has been modified to construct the API URL from a new Vite environment variable, `VITE_API_BASE_URL`.

This change allows for better separation of concerns and leverages the strengths of both platforms: Vercel for the frontend and Cloud Run for the long-running, stream-based backend.

**Post-merge instructions for you:**
1.  Set the `VITE_API_BASE_URL` environment variable in your Vercel project settings to your Cloud Run URL.
2.  Ensure your Cloud Run service's CORS policy allows requests from your Vercel domain.