### PR TITLE
feat(debug): Add test endpoint to verify streaming

### DIFF
--- a/api/test-stream.ts
+++ b/api/test-stream.ts
@@ -1,0 +1,31 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export const config = {
+  runtime: 'nodejs',
+};
+
+// A helper function to delay execution
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.status(200);
+
+  try {
+    for (let i = 1; i <= 5; i++) {
+      const chunk = `Test chunk ${i}... `;
+      res.write(`data: ${JSON.stringify({ chunk })}\n\n`);
+      await sleep(1000); // Wait for 1 second
+    }
+    res.write(`data: ${JSON.stringify({ chunk: "Stream complete!" })}\n\n`);
+    res.end();
+  } catch (error: any) {
+    console.error('Error in /api/test-stream:', error);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'An error occurred on the test stream.' });
+    }
+    res.end();
+  }
+}

--- a/components/EnhancedPromptForm.tsx
+++ b/components/EnhancedPromptForm.tsx
@@ -74,7 +74,7 @@ export default function EnhancedPromptForm() {
       },
     };
 
-    const apiUrl = `${import.meta.env.VITE_API_BASE_URL || ''}/api/enhance`;
+    const apiUrl = `${import.meta.env.VITE_API_BASE_URL || ''}/api/test-stream`;
 
     const res = await fetch(apiUrl, {
       method: 'POST',


### PR DESCRIPTION
This commit introduces a temporary test endpoint (`/api/test-stream`) to help diagnose issues with the Server-Sent Events (SSE) implementation.

Changes:
- A new API route, `/api/test-stream.ts`, has been added. This route sends a series of timed, chunked messages to the client without involving any external APIs.
- The frontend component `EnhancedPromptForm.tsx` has been temporarily modified to call this new test endpoint instead of `/api/enhance`.

This will allow you to verify that the streaming connection between the Vercel frontend and the Node.js backend is working correctly, helping to isolate the root cause of the reported issue. The changes are intended to be reverted after testing is complete.