### PR TITLE
fix(api): Add CORS headers to /api/enhance

### DIFF
--- a/api/enhance.ts
+++ b/api/enhance.ts
@@ -8,6 +8,16 @@ export const config = {
 };
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Set CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*'); // Allow any origin
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
     return;


### PR DESCRIPTION
This commit adds Cross-Origin Resource Sharing (CORS) headers to the `/api/enhance` endpoint. This is necessary to allow the Vercel-hosted frontend to make requests to the backend, which may be running on a different domain (e.g., Google Cloud Run).

Changes:
- Added `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers` to the response headers.
- Added logic to handle preflight `OPTIONS` requests, which are sent by browsers to check CORS permissions before a `POST` request.

This change should resolve the cross-origin errors that were preventing the frontend from communicating with the backend.