### PR TITLE
fix(api): Add file extension to module import

### DIFF
--- a/api/enhance.ts
+++ b/api/enhance.ts
@@ -1,7 +1,7 @@
 
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getEnhancedPrompt } from '../services/geminiService';
+import { getEnhancedPrompt } from '../services/geminiService.ts';
 
 export const config = {
   runtime: 'nodejs',


### PR DESCRIPTION
This commit fixes an `ERR_MODULE_NOT_FOUND` error that was occurring in the Vercel/Cloud Run server environment.

The error was caused by the Node.js ESM resolver not being able to find the `geminiService` module without a file extension.

The import statement in `api/enhance.ts` has been changed from: `import { getEnhancedPrompt } from '../services/geminiService';` to:
`import { getEnhancedPrompt } from '../services/geminiService.ts';`

The project's `tsconfig.json` is configured with `"allowImportingTsExtensions": true`, and this change provides the necessary information for the Vite build process to create a correctly resolved import path in the final JavaScript output.