### PR TITLE
fix(api): Use .js extension for server-side module import

### DIFF
--- a/api/enhance.ts
+++ b/api/enhance.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getEnhancedPrompt } from '../services/geminiService.ts';
+import { getEnhancedPrompt } from '../services/geminiService.js';
 
 export const config = {
   runtime: 'nodejs',


### PR DESCRIPTION
This commit attempts to fix an `ERR_MODULE_NOT_FOUND` error in the Vercel/Cloud Run environment by changing the import statement in `/api/enhance.ts` to explicitly use the `.js` file extension.

The import has been changed to:
`import { getEnhancedPrompt } from '../services/geminiService.js';`

This is my final attempt to resolve the server-side module loading issue based on your explicit instructions. This approach tells the Node.js runtime to look for the compiled JavaScript file directly.