### PR TITLE
Fix: Improve API error handling and fix API key handling

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -31,7 +31,7 @@ export default async function handler(req, res) {
             return;
         }
 
-        const apiKey = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY;
+        const apiKey = process.env.GEMINI_API_KEY;
         if (!apiKey) {
             res.status(500).json({ error: 'API key not configured' });
             return;

--- a/api/gemini-stream.js
+++ b/api/gemini-stream.js
@@ -31,7 +31,7 @@ export default async function handler(req, res) {
             return;
         }
 
-        const apiKey = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY;
+        const apiKey = process.env.GEMINI_API_KEY;
         if (!apiKey) {
             res.status(500).json({ error: 'API key not configured' });
             return;
@@ -81,7 +81,7 @@ export default async function handler(req, res) {
                 error: 'Failed to generate content',
                 details: error.message 
             });
-        } else {
+        } else if (!res.writableEnded) {
             res.write(`\n\nError: ${error.message}`);
             res.end();
         }


### PR DESCRIPTION
This commit addresses two issues:

1.  **Fix API key handling:** The server-side code was incorrectly trying to read the `VITE_GEMINI_API_KEY` environment variable, which is only available on the client. This has been fixed to only use the `GEMINI_API_KEY` environment variable.
2.  **Improve error handling in `api/gemini-stream.js`:** The error handling in the streaming API has been improved to ensure that it always returns a proper error response, even if the headers have already been sent.