### PR TITLE
fix: Correctly parse JSON response from Gemini API

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -64,7 +64,7 @@ export default async function handler(req, res) {
             config: config
         });
 
-        const rawText = response.text;
+        const rawText = response.response.candidates[0].content.parts[0].text;
         if (!rawText) {
             throw new Error('Empty response from Gemini API');
         }
@@ -82,7 +82,7 @@ export default async function handler(req, res) {
                 jsonResult = JSON.stringify(parsedJson, null, 2);
             } catch (e) {
                 const error = new Error(`The model returned invalid JSON. See raw output for details. Parser error: ${e instanceof Error ? e.message : 'unknown'}`);
-                error.cause = { rawText };
+                error.cause = { rawText: rawText };
                 throw error;
             }
         } else {


### PR DESCRIPTION
The previous implementation was attempting to access `response.text` to get the JSON string from the Gemini API response. However, when using `responseMimeType: 'application/json'`, the response object has a different structure.

This commit updates the code to access the correct path for the response text: `response.response.candidates[0].content.parts[0].text`. This ensures that the stringified JSON is correctly extracted and parsed, fixing the issue where the application was not producing results in the expected JSON structure.