### PR TITLE
I've adjusted the system instructions for Image mode with JSON output…

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -173,7 +173,11 @@ function buildSystemInstruction(mode, options) {
 
     switch (mode) {
         case 'Image':
-            modeInstruction = `The target model is a state-of-the-art AI image generator. Weave the following parameters into a fluid, descriptive paragraph. Do not just list them. The prompt should paint a vivid picture for the AI.`;
+            if (options.outputStructure !== 'SimpleJSON' && options.outputStructure !== 'DetailedJSON') {
+                modeInstruction = `The target model is a state-of-the-art AI image generator. Weave the following parameters into a fluid, descriptive paragraph. Do not just list them. The prompt should paint a vivid picture for the AI.`;
+            } else {
+                modeInstruction = `The target model is a state-of-the-art AI image generator. Your task is to populate the JSON object with the provided parameters.`;
+            }
             addParam('Style', options.imageStyle);
             addParam('Mood/Tone', options.contentTone);
             addParam('Lighting', options.lighting);


### PR DESCRIPTION
…. The previous implementation had a conflicting system instruction for the 'Image' mode that requested a 'fluid, descriptive paragraph', which overrode your request for JSON output. This caused the API to return a paragraph of text instead of a JSON object. I've modified the `buildSystemInstruction` function to provide a different, JSON-friendly instruction when the output structure is 'SimpleJSON' or 'DetailedJSON'. This ensures that the Gemini API receives a consistent set of instructions and returns the expected JSON structure.