### PR TITLE
fix: Final attempt to fix JSON output for Image mode

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -175,17 +175,17 @@ function buildSystemInstruction(mode, options) {
         case 'Image':
             if (options.outputStructure !== 'SimpleJSON' && options.outputStructure !== 'DetailedJSON') {
                 modeInstruction = `The target model is a state-of-the-art AI image generator. Weave the following parameters into a fluid, descriptive paragraph. Do not just list them. The prompt should paint a vivid picture for the AI.`;
+                addParam('Style', options.imageStyle);
+                addParam('Mood/Tone', options.contentTone);
+                addParam('Lighting', options.lighting);
+                addParam('Framing', options.framing);
+                addParam('Camera Angle', options.cameraAngle);
+                addParam('Detail Level', options.resolution);
+                addParam('Aspect Ratio', options.aspectRatio);
+                addParam('Additional Specifics', options.additionalDetails);
             } else {
                 modeInstruction = `The target model is a state-of-the-art AI image generator. Your task is to populate the JSON object with the provided parameters.`;
             }
-            addParam('Style', options.imageStyle);
-            addParam('Mood/Tone', options.contentTone);
-            addParam('Lighting', options.lighting);
-            addParam('Framing', options.framing);
-            addParam('Camera Angle', options.cameraAngle);
-            addParam('Detail Level', options.resolution);
-            addParam('Aspect Ratio', options.aspectRatio);
-            addParam('Additional Specifics', options.additionalDetails);
             break;
         case 'Video':
             modeInstruction = `The target model is a state-of-the-art AI video generator. Describe a continuous scene, focusing on motion, atmosphere, and visual storytelling.`;


### PR DESCRIPTION
This commit makes a final adjustment to the system instruction for the 'Image' mode when JSON output is requested.

The previous attempts failed because the system instruction was still confusing the Gemini API. This commit moves the `addParam` calls inside the non-JSON block in the `buildSystemInstruction` function. This prevents the parameter list from being added to the instruction when JSON output is requested, which should prevent any conflicting instructions from being sent to the API.

This is the third attempt to fix this issue, and it addresses all identified problems:
1. Correctly parsing the response.
2. Providing a JSON-friendly system instruction.
3. Removing the conflicting parameter list from the instruction.