### PR TITLE
fix: Correctly replace placeholders in directives_template

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -170,11 +170,15 @@ function buildSystemInstruction(mode, options, userPrompt) {
 
     let modalityInstruction = modalityConfig.goal;
     if (modalityConfig.directives_template) {
-        let directives = JSON.stringify(modalityConfig.directives_template);
-        for (const key in options) {
-            directives = directives.replace(new RegExp(`{{${key}}}`, 'g'), options[key]);
+        const directives = modalityConfig.directives_template;
+        for (const key in directives) {
+            const placeholder = directives[key];
+            const optionKey = placeholder.replace(/{{|}}/g, '');
+            if (options[optionKey]) {
+                directives[key] = options[optionKey];
+            }
         }
-        modalityInstruction += `\n\nDirectives:\n${directives}`;
+        modalityInstruction += `\n\nDirectives:\n${JSON.stringify(directives, null, 2)}`;
     }
 
     if (modalityConfig.key_requirements) {


### PR DESCRIPTION
The previous implementation of the prompt framework had a flaw where it would stringify the `directives_template` object before replacing the placeholders. This could lead to invalid JSON being created if the option values contained special characters.

This commit modifies the `buildSystemInstruction` function to replace the placeholders in the `directives_template` object *before* stringifying it. This ensures that the resulting JSON is always valid.