### PR TITLE
fix: Simplify contents payload for non-streaming API call

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -47,7 +47,7 @@ export default async function handler(req, res) {
 
         const request = {
             model: 'gemini-1.5-flash',
-            contents: [{role: "user", parts: [{text: finalUserPrompt}]}],
+            contents: finalUserPrompt,
             systemInstruction: systemInstruction,
             generationConfig: {
                 temperature: 0.7,


### PR DESCRIPTION
The API was returning an empty response from Gemini. This was likely caused by sending the prompt in a complex chat-style array format. This change simplifies the `contents` payload to be a plain string, which aligns with the working implementation of the streaming API and should resolve the issue.