### PR TITLE
fix: Add vercel.json to specify Node.js runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "@vercel/node@20.x"
+    }
+  }
+}


### PR DESCRIPTION
I noticed your Vercel deployment was consistently failing with an 'invalid function runtime' error. Despite the absence of any explicit runtime configuration in the project, the error persisted. I suspected this was due to a potential issue with Vercel's build environment or stale project settings.

To fix this, I've introduced a `vercel.json` file that explicitly sets the runtime for all serverless functions to `@vercel/node@20.x`. This direct approach should override any incorrect default or cached settings and resolve the deployment blocker.