### PR TITLE
fix: Correct string mismatch for JSON output format

### DIFF
--- a/api/gemini-non-stream.js
+++ b/api/gemini-non-stream.js
@@ -36,8 +36,8 @@ export default async function handler(req, res) {
         // Build system instruction based on mode and options
         const systemInstruction = buildSystemInstruction(mode, options);
 
-        const isSimpleJson = options.outputStructure === 'SimpleJSON';
-        const isDetailedJson = options.outputStructure === 'DetailedJSON';
+        const isSimpleJson = options.outputStructure === 'Simple JSON';
+        const isDetailedJson = options.outputStructure === 'Detailed JSON';
 
         const config = {
             systemInstruction,


### PR DESCRIPTION
The backend was checking for 'SimpleJSON' and 'DetailedJSON', but the frontend was sending 'Simple JSON' and 'Detailed JSON' (with a space). This caused the JSON generation logic to never be triggered.

This commit updates the string comparison in `api/gemini-non-stream.js` to match the values sent by the frontend, enabling the JSON output feature.